### PR TITLE
Querying records by fields of `date` type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 ## [Unreleased]
+### Fixed
+- Querying records by fields of `date` type with query language via `odata-adapter`.
 
 ## [0.7.1-beta.12] - 2016-11-25
 ### Fixed

--- a/addon/query/indexeddb-adapter.js
+++ b/addon/query/indexeddb-adapter.js
@@ -8,6 +8,7 @@ import { SimplePredicate, ComplexPredicate, StringPredicate, DetailPredicate } f
 import BaseAdapter from './base-adapter';
 import { getAttributeFilterFunction, buildProjection, buildOrder, buildTopSkip, buildFilter } from './js-adapter';
 import Information from '../utils/information';
+import getSerializedDateValue from '../utils/get-serialized-date-value';
 import Dexie from 'npm:dexie';
 
 /**
@@ -257,11 +258,7 @@ function updateWhereClause(store, table, query) {
         break;
 
       case 'date':
-        let dateTransform = Ember.getOwner(store).lookup('transform:date');
-        let moment = Ember.getOwner(store).lookup('service:moment');
-        let valueToTransform = moment.moment(predicate.value);
-        Ember.assert('Date value must be passed to query as JavaScript Date (instance or string) or as ISO 8601 string', valueToTransform.isValid());
-        value = dateTransform.serialize(valueToTransform.toDate());
+        value = getSerializedDateValue.call(store, predicate.value);
         break;
 
       default:

--- a/addon/query/odata-adapter.js
+++ b/addon/query/odata-adapter.js
@@ -5,6 +5,7 @@ import BaseAdapter from './base-adapter';
 import { SimplePredicate, ComplexPredicate, StringPredicate, DetailPredicate } from './predicate';
 import FilterOperator from './filter-operator';
 import Information from '../utils/information';
+import getSerializedDateValue from '../utils/get-serialized-date-value';
 
 /**
  * Class of query adapter that translates query object into OData URL.
@@ -326,6 +327,8 @@ export default class ODataAdapter extends BaseAdapter {
         value = `${type}'${predicate.value}'`;
       } else if (meta.type === 'string') {
         value = `'${predicate.value}'`;
+      } else if (meta.type === 'date') {
+        value = getSerializedDateValue.call(this._store, predicate.value);
       } else {
         value = predicate.value;
       }

--- a/addon/utils/get-serialized-date-value.js
+++ b/addon/utils/get-serialized-date-value.js
@@ -1,0 +1,9 @@
+import Ember from 'ember';
+
+export default function getSerializedDateValue(value) {
+  let dateTransform = Ember.getOwner(this).lookup('transform:date');
+  let moment = Ember.getOwner(this).lookup('service:moment');
+  let valueToTransform = moment.moment(value);
+  Ember.assert('Date value must be passed as JavaScript Date (instance or string) or as ISO 8601 string', valueToTransform.isValid());
+  return dateTransform.serialize(valueToTransform.toDate());
+}

--- a/tests/unit/CRUD/odata/execute-odata-test.js
+++ b/tests/unit/CRUD/odata/execute-odata-test.js
@@ -51,6 +51,6 @@ export default function executeTest(testName, callback) {
 
     module('CRUD | odata-' + testName);
 
-    test(testName, (assert) => callback(store, assert));
+    test(testName, (assert) => callback(store, assert, app));
   }
 }

--- a/tests/unit/CRUD/odata/odata-reading-data-types-test.js
+++ b/tests/unit/CRUD/odata/odata-reading-data-types-test.js
@@ -1,0 +1,6 @@
+import executeTest from './execute-odata-test';
+import readingDataTypes from '../base/base-reading-data-types-test';
+
+executeTest('reading | data types', (store, assert, App) => {
+  readingDataTypes(store, assert, App);
+});

--- a/tests/unit/utils/get-serialized-date-value-test.js
+++ b/tests/unit/utils/get-serialized-date-value-test.js
@@ -1,0 +1,26 @@
+import getSerializedDateValue from 'ember-flexberry-data/utils/get-serialized-date-value';
+import { module, test } from 'qunit';
+import startApp from '../../helpers/start-app';
+import Ember from 'ember';
+
+let App;
+
+module('Unit | Utility | get serialized date value', {
+  setup: function() {
+    App = startApp();
+  },
+  teardown: function() {
+    Ember.run(App, 'destroy');
+  }
+});
+
+// Replace this with your real tests.
+test('it works', function(assert) {
+  let store = App.__container__.lookup('service:store');
+  let dateTransform = App.__container__.lookup('transform:date');
+  let date = new Date(1981, 10, 12, 13, 14, 15);
+  let expectedResult = dateTransform.serialize(date);
+  let result = getSerializedDateValue.call(store, date);
+  assert.ok(result);
+  assert.equal(result, expectedResult);
+});


### PR DESCRIPTION
Querying records by fields of `date` type with query language via `odata-adapter`