### PR TITLE
Fix class name in query of IsOfPredicate

### DIFF
--- a/addon/query/odata-adapter.js
+++ b/addon/query/odata-adapter.js
@@ -235,8 +235,9 @@ export default class ODataAdapter extends BaseAdapter {
       let typeName = Ember.get(type, 'modelName');
       let namespace = Ember.get(type, 'namespace');
       let expression = predicate.expression ? this._getODataAttributeName(modelName, predicate.expression, true) : '$it';
+      let className = classify(typeName).replace(namespace.split('.').join(''), '');
 
-      return `isof(${expression},'${namespace}.${classify(typeName)}')`;
+      return `isof(${expression},'${namespace}.${className}')`;
     }
 
     if (predicate instanceof GeographyPredicate) {


### PR DESCRIPTION
If we have ember model name name-space-class-name and ORM class Name.Space.ClassName.
Before returns 'Name.Space.NameSpaceClassName'
Now returns 'Name.Space.ClassName'