### PR TITLE
Fix requests rejection when IndexedDB contains inconsistent data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+
+### Changed
+- When records stored in `IndexedDB` refer to other records that are not in `IndexedDB`, when querying those records using `IndexedDBAdapter`, you will see a warning in the console instead of a query error.
+
+## [2.5.0-beta.4] - 2020-07-22
+### Added
+- [WIP] The ability to skip data inconsistency errors when reading with the `IndexedDBAdapter` adapter.
+
 ## [2.5.0-beta.2] - 2020-06-22
 ### Added
 - Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## [Unreleased]
 
-## [2.5.0-beta.4] - 2020-07-22
-### Added
-- [WIP] The ability to skip data inconsistency errors when reading with the `IndexedDBAdapter` adapter.
-
 ## [2.5.0-beta.2] - 2020-06-22
 ### Added
 - Store

--- a/addon/query/indexeddb-adapter.js
+++ b/addon/query/indexeddb-adapter.js
@@ -22,11 +22,10 @@ import Queue from '../utils/queue';
 export default class extends BaseAdapter {
   /**
     @param {Dexie} db Dexie database instance.
-    @param {Boolean} [skipConstraintsErrors=false] If `true`, errors of inconsistency of data will be replaced by warnings.
     @class IndexedDBAdapter
     @constructor
   */
-  constructor(db, skipConstraintsErrors = false) {
+  constructor(db) {
     super();
 
     if (!db) {
@@ -34,7 +33,6 @@ export default class extends BaseAdapter {
     }
 
     this._db = db;
-    this._skipConstraintsErrors = skipConstraintsErrors;
   }
 
   /**
@@ -125,14 +123,10 @@ export default class extends BaseAdapter {
             if (masterKey > masterDataValue[masterPrimaryKeyName] && masterIndex < masterDataLength) {
               masterIndex++;
             } else if (masterKey < masterDataValue[masterPrimaryKeyName] || masterIndex >= masterDataLength) {
-              const errorMessage = `Data constraint error. Not found object type '${masterTypeName}' with id '${masterKey}'. ` +
-                `It used in object of type '${dataTypeName}' with id '${data[dataIndex].id}'.`;
-              if (_this._skipConstraintsErrors) {
-                Ember.warn(errorMessage, false, { id: 'ember-flexberry-data-debug.offline.indexeddb-inconsistent-database' });
-              } else {
-                reject(new Error(errorMessage));
-              }
-
+              let objectId = data[dataIndex].id;
+              let error = new Error(`Data constraint error. Not found object type '${masterTypeName}' with id ${masterKey}. ` +
+              `It used in object of type '${dataTypeName}' with id '${objectId}'`);
+              reject(error);
               break;
             }
 
@@ -161,14 +155,10 @@ export default class extends BaseAdapter {
             let detailObj = detailsData.get(detailKey);
 
             if (!detailObj) {
-              const errorMessage = `Data constraint error. Not found object type '${detailsTypeName}' with id '${detailKey}'. ` +
-                `It used in object of type '${dataTypeName}' with id '${data[dataIndex].id}'.`;
-              if (_this._skipConstraintsErrors) {
-                Ember.warn(errorMessage, false, { id: 'ember-flexberry-data-debug.offline.indexeddb-inconsistent-database' });
-              } else {
-                reject(new Error(errorMessage));
-              }
-
+              let objectId = data[dataIndex].id;
+              let error = new Error(`Data constraint error. Not found object type '${detailsTypeName}' with id ${detailKey}. ` +
+              `It used in object of type '${dataTypeName}' with id '${objectId}'`);
+              reject(error);
               break;
             }
 

--- a/addon/query/indexeddb-adapter.js
+++ b/addon/query/indexeddb-adapter.js
@@ -107,15 +107,12 @@ export default class extends BaseAdapter {
           while (moveMastersForvard) {
             let masterDataValue = masterData[masterIndex];
 
-            // TODO: Check if Debug Mode build then use this.
             if (!masterDataValue || !masterDataValue.hasOwnProperty(masterPrimaryKeyName)) {
-              const errorMessage = 'Metadata consistance error. ' +
-                `Not found property '${masterPrimaryKeyName}' in type '${masterTypeName}'.`;
-              if (_this._skipConstraintsErrors) {
-                Ember.warn(errorMessage, false, { id: 'ember-flexberry-data-debug.offline.indexeddb-inconsistent-database' });
-              } else {
-                reject(new Error(errorMessage));
-              }
+              Ember.warn(
+                `Metadata consistance error. Not found property '${masterPrimaryKeyName}' in type '${masterTypeName}'.`,
+                false,
+                { id: 'ember-flexberry-data-debug.offline.indexeddb-inconsistent-database' }
+              );
 
               break;
             }
@@ -123,10 +120,13 @@ export default class extends BaseAdapter {
             if (masterKey > masterDataValue[masterPrimaryKeyName] && masterIndex < masterDataLength) {
               masterIndex++;
             } else if (masterKey < masterDataValue[masterPrimaryKeyName] || masterIndex >= masterDataLength) {
-              let objectId = data[dataIndex].id;
-              let error = new Error(`Data constraint error. Not found object type '${masterTypeName}' with id ${masterKey}. ` +
-              `It used in object of type '${dataTypeName}' with id '${objectId}'`);
-              reject(error);
+              Ember.warn(
+                `Data constraint error. Not found object type '${masterTypeName}' with id '${masterKey}'. ` +
+                `It used in object of type '${dataTypeName}' with id '${data[dataIndex].id}'.`,
+                false,
+                { id: 'ember-flexberry-data-debug.offline.indexeddb-inconsistent-database' }
+              );
+
               break;
             }
 
@@ -155,11 +155,14 @@ export default class extends BaseAdapter {
             let detailObj = detailsData.get(detailKey);
 
             if (!detailObj) {
-              let objectId = data[dataIndex].id;
-              let error = new Error(`Data constraint error. Not found object type '${detailsTypeName}' with id ${detailKey}. ` +
-              `It used in object of type '${dataTypeName}' with id '${objectId}'`);
-              reject(error);
-              break;
+              Ember.warn(
+                `Data constraint error. Not found object type '${detailsTypeName}' with id ${detailKey}. ` +
+                `It used in object of type '${dataTypeName}' with id '${data[dataIndex].id}'.`,
+                false,
+                { id: 'ember-flexberry-data-debug.offline.indexeddb-inconsistent-database' }
+              );
+
+              continue;
             }
 
             detailsObjects.push(detailObj);


### PR DESCRIPTION
При чтении из `IndexedDB` проверяется наличие связей, и в случае их отсутствия, запрос завершается с ошибкой.
Такое возможно когда, например, в `IndexenDB` не загружена таблица, на которую есть ссылки, или не полностью загружена иерархическая таблица.

Вместо того чтобы завершать весь запрос с ошибкой, при отсутствии связей, можно отдавать то что есть, и ограничиться предупреждением.