### PR TITLE
Fix batch update for offline adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Breaking changes
+- The implementation of the `batchUpdate` method in the `Adapter.Offline` adapter has been removed, and the `save` method is now used instead.
+
 ## [2.5.0-beta.4] - 2020-07-22
 ### Added
 - [WIP] The ability to skip data inconsistency errors when reading with the `IndexedDBAdapter` adapter.

--- a/addon/adapters/offline.js
+++ b/addon/adapters/offline.js
@@ -429,103 +429,12 @@ export default DS.Adapter.extend({
   },
 
   /**
-    Performing batch update operaion.
+    This method is not implemented.
 
     @method batchUpdate
-    @param {DS.Store} store
-  	@param {DS.Model[]|DS.Model} models Is array of models or single model for batch update.
-    @return {Promise}
   */
-  batchUpdate(store, models) {
-    if (Ember.isEmpty(models)) {
-      return Ember.RSVP.resolve(models);
-    }
-
-    models = Ember.isArray(models) ? models : Ember.A([models]);
-
-    const dexieService = this.get('dexieService');
-    const db = dexieService.dexie(this.get('dbName'), store);
-
-    return Ember.RSVP.all(models.map((m) => m.save({ softSave: true }))).then(() => {
-
-      const modelsMap = {};
-
-      models.forEach((model) => {
-        const snapshot = model._createSnapshot();
-        const modelName = snapshot.modelName;
-        const serializer = store.serializerFor(modelName);
-
-        modelsMap[modelName] = modelsMap[modelName] || { add: [], update: [], delete: [] };
-
-        const dirtyType = model.get('dirtyType') || model.hasChangedBelongsTo() ? 'updated' : undefined;
-
-        switch (dirtyType) {
-          case 'created':
-            modelsMap[modelName].add.push(serializer.serialize(snapshot, { includeId: true }));
-            break;
-
-          case 'updated':
-            modelsMap[modelName].update.push(serializer.serialize(snapshot, { includeId: true }));
-            break;
-
-          case 'deleted':
-            modelsMap[modelName].delete.push(model.get('id'));
-            break;
-        }
-      });
-
-      const tableNames = Object.keys(modelsMap);
-      const batchUpdateOperation = (db) => db.transaction('rw', tableNames, () => new Dexie.Promise((resolve, reject) => {
-        const promises = [];
-        tableNames.forEach((tableName) => {
-          const table = db.table(tableName);
-          const mapItem = modelsMap[tableName];
-
-          if (mapItem.add.length) {
-            promises.push(table.bulkAdd(mapItem.add));
-          }
-
-          if (mapItem.update.length) {
-            promises.push(table.bulkPut(mapItem.update));
-          }
-
-          if (mapItem.delete.length) {
-            promises.push(table.bulkDelete(mapItem.delete));
-          }
-        });
-
-        Dexie.Promise.all(promises).then(() => {
-          Dexie.Promise.all(models.map((model) => {
-            const modelName = model.constructor.modelName;
-            const { id, dirtyType } = model.getProperties('id', 'dirtyType');
-
-            return dirtyType === 'deleted' ? Dexie.Promise.resolve(null) : db.table(modelName).get(id);
-          })).then((rawModels) => {
-            resolve(models.map((model, index) => {
-              if (model.get('dirtyType') === 'deleted') {
-                Ember.run(store, store.unloadRecord, model);
-              }
-
-              const rawModel = rawModels[index];
-              if (rawModel) {
-                const modelName = model.constructor.modelName;
-                const modelClass = store.modelFor(modelName);
-                const serializer = store.serializerFor(modelName);
-
-                Ember.run(store, store.push, serializer.normalize(modelClass, rawModel));
-                Ember.run(model, model.rollbackAttributes);
-
-                return model;
-              }
-
-              return null;
-            }));
-          }).catch(reject);
-        }).catch(reject);
-      }));
-
-      return dexieService.performOperation(db, batchUpdateOperation);
-    });
+  batchUpdate() {
+    throw new Error('Not implemented.');
   },
 
   /**

--- a/addon/serializers/offline.js
+++ b/addon/serializers/offline.js
@@ -25,25 +25,6 @@ export default DS.JSONSerializer.extend({
   },
 
   /**
-    If the adapter returns the `belongsTo` relation as an identifier, we will replace it with an object with the `id` property.
-
-    See [EmberJS API](https://emberjs.com/api/).
-
-    @param {DS.Model} typeClass
-    @param {Object} hash
-    @return {Object}
-  */
-  normalize(typeClass, hash) {
-    typeClass.eachRelationship((name, { kind }) => {
-      if (kind === 'belongsTo' && typeof hash[name] === 'string') {
-        hash[name] = { id: hash[name] };
-      }
-    });
-
-    return this._super(...arguments);
-  },
-
-  /**
     Returns the resource's attributes formatted as a JSON-API "attributes object".
     [More info](http://emberjs.com/api/data/classes/DS.JSONSerializer.html#method_extractAttributes).
 

--- a/addon/stores/local-store.js
+++ b/addon/stores/local-store.js
@@ -229,9 +229,7 @@ export default DS.Store.extend({
   },
 
   /**
-    A method to send batch update, create or delete models in single transaction.
-
-    All models saving using this method must have identifiers.
+    Calls the `save` method on each passed model and returns a promise that is resolved by an array of saved models.
 
     The array which fulfilled the promise may contain the following values:
     - `same model object` - for created, updated or unaltered records.
@@ -242,7 +240,13 @@ export default DS.Store.extend({
     @return {Promise} A promise that fulfilled with an array of models in the new state.
   */
   batchUpdate(models) {
-    return this.adapterFor('application').batchUpdate(this, models);
+    return Ember.RSVP.all(Ember.isArray(models) ? models.map((model) => {
+      if (model.get('dirtyType') === 'deleted') {
+        return model.save().then(() => null);
+      }
+
+      return model.save();
+    }) : [models.save()]);
   },
 
   /**


### PR DESCRIPTION
При использовании пакетного обновления в оффлайне, выявились проблемы работы с наследуемыми моделями, и полиморфными связями.
Скорее всего, при исправлении проблем, не получиться сохранить единую транзакцию для всего запроса.
Сейчас не понятна мотивация для исправления этих проблем, поэтому реализация была заменена на «простое» сохранение.