### PR TITLE
Added processing of errors on batch update.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -93,7 +93,7 @@ tests/integration/services/syncer-test.js
 tests/integration/transforms/decimal-test.js
 tests/unit/CRUD/base/association-batch-updating-test.js
 tests/unit/CRUD/base/base-batch-updating-test.js
-tests/unit/CRUD/base/base-updating-fail-test.js
+tests/unit/CRUD/base/base-batch-updating-fail-test.js
 tests/unit/CRUD/base/base-creating-test.js
 tests/unit/CRUD/base/base-deleting-test.js
 tests/unit/CRUD/base/base-deleting-with-details-test.js
@@ -117,7 +117,7 @@ tests/unit/CRUD/base/base-updating-test.js
 tests/unit/CRUD/odata/execute-odata-test.js
 tests/unit/CRUD/odata/odata-association-batch-updating-test.js
 tests/unit/CRUD/odata/odata-batch-updating-test.js
-tests/unit/CRUD/odata/odata-updating-fail-test.js
+tests/unit/CRUD/odata/odata-batch-updating-fail-test.js
 tests/unit/CRUD/odata/odata-creating-test.js
 tests/unit/CRUD/odata/odata-deleting-test.js
 tests/unit/CRUD/odata/odata-deleting-with-details-test.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -93,6 +93,7 @@ tests/integration/services/syncer-test.js
 tests/integration/transforms/decimal-test.js
 tests/unit/CRUD/base/association-batch-updating-test.js
 tests/unit/CRUD/base/base-batch-updating-test.js
+tests/unit/CRUD/base/base-updating-fail-test.js
 tests/unit/CRUD/base/base-creating-test.js
 tests/unit/CRUD/base/base-deleting-test.js
 tests/unit/CRUD/base/base-deleting-with-details-test.js
@@ -116,6 +117,7 @@ tests/unit/CRUD/base/base-updating-test.js
 tests/unit/CRUD/odata/execute-odata-test.js
 tests/unit/CRUD/odata/odata-association-batch-updating-test.js
 tests/unit/CRUD/odata/odata-batch-updating-test.js
+tests/unit/CRUD/odata/odata-updating-fail-test.js
 tests/unit/CRUD/odata/odata-creating-test.js
 tests/unit/CRUD/odata/odata-deleting-test.js
 tests/unit/CRUD/odata/odata-deleting-with-details-test.js

--- a/addon/adapters/odata.js
+++ b/addon/adapters/odata.js
@@ -533,7 +533,15 @@ export default DS.RESTAdapter.extend({
           return reject(new DS.AdapterError('Invalid response type.'));
         }
 
-        const batchResponses = getBatchResponses(response, meta.boundary).map(parseBatchResponse);
+        let batchResponses;
+
+        try {
+          batchResponses = getBatchResponses(response, meta.boundary).map(parseBatchResponse);
+        } catch (error) {
+          // If an error is thrown then this situation is not processed and user will get not understandable result.
+          return reject(new DS.AdapterError(error));
+        }
+
         const getResponses = batchResponses.filter(r => r.contentType === 'application/http');
         const updateResponse = batchResponses.find(r => r.contentType === 'multipart/mixed');
 

--- a/addon/utils/batch-queries.js
+++ b/addon/utils/batch-queries.js
@@ -105,7 +105,20 @@ function parseResponse(response) {
       break;
 
     case 'application/json':
-      body = JSON.parse(response.substring(startBody));
+      let parsedString = response.substring(startBody);
+      body = JSON.parse(parsedString);
+
+      /* There can be an error on server so result will be parsed but will not be applied and will lead to not understandable error.
+        {"error":{"code":"500","message":"An error has occured."}}
+      */
+      if (parsedString.replace('\n', '').startsWith('{"error"')
+          && body.hasOwnProperty('error')
+          && body['error'].hasOwnProperty('code')
+          && body['error'].hasOwnProperty('message')){
+        let errorCode = body['error']['code'];
+        let errorMessage = body['error']['message'];
+        throw new Error(`Request failed, error ${errorCode}: ${errorMessage}`);
+      }
       break;
 
     default:

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -50,7 +50,7 @@ module.exports = function(environment) {
     ENV.APP.rootElement = '#ember-testing';
 
     // URL of the backend running in docker
-    var testODataServiceURL = 'http://localhost:6500/odata';
+    var testODataServiceURL = 'http://localhost:80/odata';
 
     ENV.APP.testODataService = !!testODataServiceURL;
     ENV.APP.testODataServiceURL = testODataServiceURL;

--- a/tests/unit/CRUD/base/base-batch-updating-fail-test.js
+++ b/tests/unit/CRUD/base/base-batch-updating-fail-test.js
@@ -45,11 +45,16 @@ export default function batchUpdateWithFail(store, assert) {
         return store.batchUpdate(Ember.A([recordUser, recordSuggestion, recordComment, recordType]))
         .then(() => {
           // There should be an error on batch update.
-          assert.ok(false, "There should be an error on batch update. This update should not be executed.");
+          console.log("There should be an error on batch update. This update should not be executed.");
+        },
+        (rejectResult) => {
+          if (rejectResult instanceof DS.AdapterError) {
+            assert.ok(true, "Reject was executed as expected.");
+            console.log("Reject was executed as expected. " + Ember.get(rejectResult, "errors"));
+          } 
         })
         .catch((e2) => {
-          console.log(e2, "Batch update failed as expected. " + e2.message);
-          assert.ok(true);
+          console.log(e2, "Batch update should be rejected, not catched. " + e2.message);
           recordSuggestion.destroyRecord();
           throw e2;
         })

--- a/tests/unit/CRUD/base/base-batch-updating-fail-test.js
+++ b/tests/unit/CRUD/base/base-batch-updating-fail-test.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import DS from 'ember-data';
 
 export default function batchUpdateWithFail(store, assert) {
   assert.expect(1);
@@ -27,7 +28,7 @@ export default function batchUpdateWithFail(store, assert) {
           }),
         store.findRecord('ember-flexberry-dummy-comment', commentId)
           .then((returned3Record) => {
-            Ember.set(returned3Record, 'text', 'Test');
+            Ember.set(returned3Record, 'text', 'Test 11111111-1111-1111-1111-111111111111');
             return returned3Record;
           }),
         store.findRecord('ember-flexberry-dummy-suggestion', suggestionId)
@@ -109,7 +110,6 @@ function initTestData(store) {
     // Creating comments.
     .then((sug) =>
       store.createRecord('ember-flexberry-dummy-comment', {
-        id: "11111111-1111-1111-1111-111111111111",
         author: sugAttrs[0],
         text: 'No exception',
         suggestion: sug[0],

--- a/tests/unit/CRUD/base/base-batch-updating-fail-test.js
+++ b/tests/unit/CRUD/base/base-batch-updating-fail-test.js
@@ -1,0 +1,139 @@
+import Ember from 'ember';
+
+export default function batchUpdateWithFail(store, assert) {
+  assert.expect(3);
+  let done = assert.async();
+
+  Ember.run(() => {
+    initTestData(store)
+
+    // Without relationships.
+    .then((records) => {
+      const userId = records.people;
+      const sugTypeId = records.type;
+      const suggestionId = records.suggestion;
+      const commentId = records.comment;
+
+      return Ember.RSVP.Promise.all([
+        store.findRecord('ember-flexberry-dummy-application-user', userId)
+          .then((returned1Record) => {
+            Ember.set(returned1Record, 'name', 'Updated value');
+            return returned1Record;
+          }),
+        store.findRecord('ember-flexberry-dummy-suggestion-type', sugTypeId)
+          .then((returned2Record) => {
+            Ember.set(returned2Record, 'name', 'Updated value');
+            return returned2Record;
+          }),
+        store.findRecord('ember-flexberry-dummy-comment', commentId)
+          .then((returned3Record) => {
+            Ember.set(returned3Record, 'text', 'Test');
+            return returned3Record;
+          }),
+        store.findRecord('ember-flexberry-dummy-suggestion', suggestionId)
+          .then((returned4Record) => {
+            return returned4Record;
+          })
+      ])
+      .then((recordsForBatch) => {
+        const recordUser = recordsForBatch[0];
+        const recordType = recordsForBatch[1];
+        const recordComment = recordsForBatch[2];
+        const recordSuggestion = recordsForBatch[3];
+
+        let done2 = assert.async();
+        return store.batchUpdate(Ember.A([recordUser, recordSuggestion, recordComment, recordType]))
+        .then((result) => {
+          // There should be an error on batch update.
+          assert.ok(false, "There should be an error on batch update. This update should not be executed.");
+        })
+        .catch((e2) => {
+          console.log(e2, "Batch update failed as expected. " + e2.message);
+          assert.ok(true);
+        })
+        .finally(() => {
+          let done3 = assert.async();
+          recordSuggestion.deleteRecord();
+          store.batchUpdate(Ember.A([recordSuggestion]))
+          .catch((e3) => {
+            console.log(e3, "Error during deleting test data." + e3.message);
+            assert.ok(true);
+            throw e3;
+          })
+          .finally(done3);
+          done2;
+        });
+      })  
+    })
+    .catch((e) => {
+      console.log(e, "Global error." + e.message);
+      throw e;
+    })
+    .finally(done);
+  });
+}
+
+function initTestData(store) {
+
+  // Parent type
+  return store.createRecord('ember-flexberry-dummy-suggestion-type', {
+    name: 'Parent type'
+  }).save()
+
+  // Attrs for creating suggestion.
+  .then((parentType) =>
+    Ember.RSVP.Promise.all([
+      store.createRecord('ember-flexberry-dummy-application-user', {
+        name: 'Vasya',
+        eMail: '1@mail.ru',
+      }).save(),
+
+      store.createRecord('ember-flexberry-dummy-suggestion-type', {
+        name: 'Type 1',
+        parent: parentType
+      }).save()
+    ])
+  )
+
+  // Сreating suggestion.
+  .then((sugAttrs) =>
+    Ember.RSVP.Promise.all([
+      store.createRecord('ember-flexberry-dummy-suggestion', {
+        type: sugAttrs[1],
+        author: sugAttrs[0],
+        editor1: sugAttrs[0]
+      }).save(),
+
+      store.createRecord('ember-flexberry-dummy-suggestion', {
+        type: sugAttrs[1],
+        author: sugAttrs[0],
+        editor1: sugAttrs[0]
+      }).save()
+    ])
+
+    // Creating comments.
+    .then((sug) =>
+      store.createRecord('ember-flexberry-dummy-comment', {
+        id: "11111111-1111-1111-1111-111111111111",
+        author: sugAttrs[0],
+        text: 'No exception',
+        suggestion: sug[0],
+      }).save()
+
+      // It is necessary to fill 'detail' at 'master' in offline.
+      .then((commentItem) => store._isOnline() ? Ember.RSVP.resolve(commentItem) : sug.save().then(() => Ember.RSVP.resolve(commentItem)))
+
+      // Returns.
+      .then((commentItem) =>
+        new Ember.RSVP.Promise(resolve =>
+          resolve({
+            people: Ember.get(sugAttrs[0], 'id'),
+            type: Ember.get(sugAttrs[1], 'id'),
+            suggestion: Ember.get(sug[0], 'id'),
+            comment: Ember.get(commentItem, 'id')
+          })
+        )
+      )
+    )
+  );
+}

--- a/tests/unit/CRUD/base/base-batch-updating-fail-test.js
+++ b/tests/unit/CRUD/base/base-batch-updating-fail-test.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 
 export default function batchUpdateWithFail(store, assert) {
-  assert.expect(3);
+  assert.expect(1);
   let done = assert.async();
 
   Ember.run(() => {
@@ -43,31 +43,21 @@ export default function batchUpdateWithFail(store, assert) {
 
         let done2 = assert.async();
         return store.batchUpdate(Ember.A([recordUser, recordSuggestion, recordComment, recordType]))
-        .then((result) => {
+        .then(() => {
           // There should be an error on batch update.
           assert.ok(false, "There should be an error on batch update. This update should not be executed.");
         })
         .catch((e2) => {
           console.log(e2, "Batch update failed as expected. " + e2.message);
           assert.ok(true);
+          recordSuggestion.destroyRecord();
+          throw e2;
         })
-        .finally(() => {
-          let done3 = assert.async();
-          recordSuggestion.deleteRecord();
-          store.batchUpdate(Ember.A([recordSuggestion]))
-          .catch((e3) => {
-            console.log(e3, "Error during deleting test data." + e3.message);
-            assert.ok(true);
-            throw e3;
-          })
-          .finally(done3);
-          done2;
-        });
+        .finally(done2);
       })  
     })
     .catch((e) => {
       console.log(e, "Global error." + e.message);
-      throw e;
     })
     .finally(done);
   });

--- a/tests/unit/CRUD/odata/execute-odata-test.js
+++ b/tests/unit/CRUD/odata/execute-odata-test.js
@@ -15,7 +15,7 @@ export default function executeTest(testName, callback, skipTest) {
     if (config.APP.testODataServiceURL.indexOf('http') >= 0) {
       baseUrl = config.APP.testODataServiceURL;
     } else {
-      baseUrl = 'http://localhost:6500/odata';
+      baseUrl = 'http://localhost:80/odata';
     }
 
     const app = startApp();

--- a/tests/unit/CRUD/odata/odata-batch-updating-fail-test.js
+++ b/tests/unit/CRUD/odata/odata-batch-updating-fail-test.js
@@ -1,0 +1,6 @@
+import executeTest from './execute-odata-test';
+import batchUpdateWithFail from '../base/base-batch-updating-fail-test';
+
+executeTest('batchUpdating-fail', (store, assert) => {
+  batchUpdateWithFail(store, assert);
+});


### PR DESCRIPTION
When error happens on backend side during batch update, odata adapter now throws an error (otherwise parsed object is processed as returned model and adapter returns strange errors).
All errors from response parsing are catched now. This errors lead to reject answer of batch update.

A test for this situation is added.
Code was tested throught primary using of batchUpdate and error was catched on reject-state.
Code was tested on edit form where batchUpdate was used. Error was catched on "onSaveActionRejected(errorData)".

Fixes #236.